### PR TITLE
Fix duplicate section IDs for Projects section

### DIFF
--- a/csi.html
+++ b/csi.html
@@ -79,7 +79,7 @@
 
     <h2>Projects</h2>
   
-    <section id="projects">
+    <section id="other-projects">
 
       <div class="projects">
     


### PR DESCRIPTION
Changed the ID of the second "Projects" section to ensure uniqueness within the document. Renamed the ID from "projects" to "other-projects".